### PR TITLE
Added workaround for annoying docker bug

### DIFF
--- a/captain/connection.py
+++ b/captain/connection.py
@@ -58,13 +58,13 @@ class Connection(object):
                 # this is a workaround for docker's annoying 'feature'
                 if formatted_exit_time == '0001-01-01T00:00:00Z':
                     logging.warn("Detected container {} with zero exit time on {}. Will attempt to start and kill.".format(container["Id"], node))
-                    node_conn.start_container(container["Id"])
-                    node_conn.kill_container(container["Id"])
+                    node_conn.start(container["Id"])
+                    node_conn.kill(container["Id"])
                     logging.warn("Container {} exit time successfully reset.".format(container["Id"]))
                 elif (datetime.datetime.now() - exit_time).total_seconds() > self.config.docker_gc_grace_period:
                     logging.warn("Will recycle container {} on {} with exit time at {}".format(container["Id"], node, formatted_exit_time))
                     node_conn.remove_container(container["Id"])
-                    logging.info("Removed {} from {}".format(container["Id"], node))
+                    logging.warn("Removed {} from {}".format(container["Id"], node))
             elif len(container["Ports"]) == 1 and container["Ports"][0]["PrivatePort"] == 8080:
                 node_container = self._get_lru_instance_details(node, container["Id"], container_status)
                 node_instances.append(self.__get_instance(node, node_container))

--- a/captain/tests/test_connection.py
+++ b/captain/tests/test_connection.py
@@ -60,9 +60,14 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(2, instance3["environment"].__len__())
         self.assertEqual("-Dapplication.log=INFO -Drun.mode=Prod -Dlogger.resource=/application-json-logger.xml -Dhttp.port=8080", instance3["environment"]["HMRC_CONFIG"])
         self.assertEqual("-Xmx256m -Xms256m", instance3["environment"]["JAVA_OPTS"])
-        # Two containers stopped, one of them for longer than docker_gc_grace_period
-        docker_conn1.remove_container.assert_has_calls([call("381587e2978216"), call("3815178hgdasf6")])
-        self.assertEqual(docker_conn1.remove_container.call_count, 2)
+        # One container stopped
+        docker_conn1.remove_container.assert_has_calls([call("381587e2978216")])
+        # One container with FinishedAt time of 0 started and killed
+        docker_conn1.start.assert_has_calls([call("3815178hgdasf6")])
+        docker_conn1.kill.assert_has_calls([call("3815178hgdasf6")])
+        self.assertEqual(docker_conn1.remove_container.call_count, 1)
+        self.assertEqual(docker_conn1.start.call_count, 1)
+        self.assertEqual(docker_conn1.kill.call_count, 1)
         self.assertEqual(docker_conn2.remove_container.call_count, 0)
         # jh23899fg00029 doesn't have captain ports defined and should be ignored.
         self.assertFalse([i for i in instances if i["id"] == "jh23899fg00029"])


### PR DESCRIPTION
When a server is rebooted, docker will report an exit time of `0001-01-01T00:00:00Z`.
Captain will then remove that container as part of its garbage collection process.

This PR adds a workaround where captain will just try to `start` and immediately `kill` a container. That will reset the `FinishedAt` time and captain will not remove the container.
