### PR TITLE
Instance summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+captain-venv
 
 # Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: python
 python:
   - "2.7"
 script: "./jenkins.sh"
+sudo: false

--- a/captain/connection.py
+++ b/captain/connection.py
@@ -10,6 +10,7 @@ import struct
 import logging
 from concurrent import futures
 from backports.functools_lru_cache import lru_cache as lru_cache
+from collections import Counter
 
 lru_cache_size = 1024
 
@@ -126,6 +127,19 @@ class Connection(object):
                     nodes = nodes + [future.result()]
                     logging.debug("Got details for {}".format(node))
         return nodes
+
+    def get_instance_summary(self):
+        summary = {"total_instances": 0}
+        apps = Counter()
+        logging.debug("Getting instances to generate summary")
+        instances = self.get_instances()
+        for instance in instances:
+            summary["total_instances"] += 1
+            apps[instance["app"]] += 1
+            logging.debug("Incrementing {} to {}".format(instance["app"], apps[instance["app"]]))
+        summary.update({"apps": dict(apps)})
+        logging.debug("Returning summary {}".format(summary))
+        return summary
 
     def start_instance(self, app, slug_uri, node, allocated_port=None, environment={}, slots=None, hostname=None):
         environment["PORT"] = "8080"

--- a/captain/tests/test_connection.py
+++ b/captain/tests/test_connection.py
@@ -20,6 +20,21 @@ class TestConnection(unittest.TestCase):
         self.config.default_slots_per_instance = 2
 
     @patch('docker.Client')
+    def test_returns_summary_of_instances(self, docker_client):
+        # given
+        (docker_conn1, docker_conn2, docker_conn3) = ClientMock().mock_two_docker_nodes(docker_client)
+
+        # when
+        connection = Connection(self.config)
+        summary = connection.get_instance_summary()
+
+        # then
+        print summary
+        self.assertEqual(3, summary['total_instances'])
+        self.assertEqual(1, summary['apps']['ers-checking-frontend-27'])
+        self.assertEqual(2, summary['apps']['paye'])
+
+    @patch('docker.Client')
     def test_returns_all_instances_with_ports(self, docker_client):
         # given
         (docker_conn1, docker_conn2, docker_conn3) = ClientMock().mock_two_docker_nodes(docker_client)

--- a/captain_web.py
+++ b/captain_web.py
@@ -111,7 +111,7 @@ api.add_resource(RestInstances, '/instances/')
 api.add_resource(RestInstance, '/instances/<string:instance_id>')
 api.add_resource(RestInstanceLogs, '/instances/<string:instance_id>/logs')
 api.add_resource(RestPing, '/ping/ping')
-api.add_resource(RestInstancesSummary, '/instances/summary/')
+api.add_resource(RestInstancesSummary, '/instances_summary/')
 
 
 class RestNodes(restful.Resource):

--- a/captain_web.py
+++ b/captain_web.py
@@ -101,10 +101,17 @@ class RestPing(restful.Resource):
         return ({}, 204)
 
 
+class RestInstancesSummary(restful.Resource):
+    def get(self):
+        captain_conn = get_captain_conn()
+        return captain_conn.get_instance_summary()
+
+
 api.add_resource(RestInstances, '/instances/')
 api.add_resource(RestInstance, '/instances/<string:instance_id>')
 api.add_resource(RestInstanceLogs, '/instances/<string:instance_id>/logs')
 api.add_resource(RestPing, '/ping/ping')
+api.add_resource(RestInstancesSummary, '/instances/summary/')
 
 
 class RestNodes(restful.Resource):


### PR DESCRIPTION
When monitoring a group of docker nodes via captain it makes sense to provide a summary of the instances running rather than having clients doing it.