### PR TITLE
WEBOPS-3348 Handle bad node config

### DIFF
--- a/captain/connection.py
+++ b/captain/connection.py
@@ -26,11 +26,14 @@ class Connection(object):
         self.node_connections = {}
         logger.debug(dict(message="Setting up docker clients for {} configured nodes".format(len(config.docker_nodes))))
         for node in config.docker_nodes:
-            address = urlparse(node)
-            docker_conn = self.__get_connection(address)
-            docker_conn.verify = verify
-            docker_conn.auth = (address.username, address.password)
-            self.node_connections[address.hostname] = docker_conn
+            try:
+                address = urlparse(node)
+                docker_conn = self.__get_connection(address)
+                docker_conn.verify = verify
+                docker_conn.auth = (address.username, address.password)
+                self.node_connections[address.hostname] = docker_conn
+            except Exception:
+                logger.exception('Failed to add node from config: {}'.format(node))
         logger.debug(dict(message='Nodes configured: {}'.format(self.node_connections)))
 
     def close(self):

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,3 +3,4 @@ coverage==3.7.1
 mock==1.0.1
 nose==1.3.3
 nosexcover==1.0.10
+testfixtures==4.10.0


### PR DESCRIPTION
When a node in the DOCKER_NODES env var is badly formated handle any exception caused to allow the other configured nodes to continue working