### PR TITLE
Add api parameter to control the version of slug_runner

### DIFF
--- a/captain/config.py
+++ b/captain/config.py
@@ -17,5 +17,6 @@ class Config(object):
             raise Exception("SLUG_RUNNER_COMMAND should be specified")
 
         self.slug_runner_image = os.getenv("SLUG_RUNNER_IMAGE")
+        self.slug_runner_version = os.getenv("SLUG_RUNNER_VERSION", "0.0.0")
         if self.slug_runner_image is None:
             raise Exception("SLUG_RUNNER_IMAGE should be specified")

--- a/captain/connection.py
+++ b/captain/connection.py
@@ -166,7 +166,7 @@ class Connection(object):
         logger.debug(dict(message="Returning summary {}".format(summary)))
         return summary
 
-    def start_instance(self, app, slug_uri, node, allocated_port=None, environment={}, slots=None, hostname=None):
+    def start_instance(self, app, slug_uri, node, allocated_port=None, environment={}, slots=None, hostname=None, slug_runner_version=None):
         environment["PORT"] = "8080"
         environment["SLUG_URL"] = slug_uri
 
@@ -181,8 +181,14 @@ class Connection(object):
 
         node_connection = self.node_connections[node]
 
+        # Use the version from the api parameter if it's set, otherwise use the version from config
+        if slug_runner_version is None:
+            slug_runner_versioned_image = "{}:{}".format(self.config.slug_runner_image, self.config.slug_runner_version)
+        else:
+            slug_runner_versioned_image = "{}:{}".format(self.config.slug_runner_image, slug_runner_version)
+
         # create a container
-        container = node_connection.create_container(image=self.config.slug_runner_image,
+        container = node_connection.create_container(image=slug_runner_versioned_image,
                                                      command=self.config.slug_runner_command,
                                                      ports=[8080],
                                                      environment=environment,

--- a/captain/tests/test_config.py
+++ b/captain/tests/test_config.py
@@ -10,6 +10,7 @@ class TestConfig(unittest.TestCase):
     DOCKER_NODE_2 = "http://some-node-2:5000"
     SLUG_RUNNER_COMMAND = "some command"
     SLUG_RUNNER_IMAGE = "runner/image"
+    SLUG_RUNNER_VERSION = "0.0.73"
     DOCKER_GC_GRACE_PERIOD = "100"
     SLOTS_PER_NODE = "10"
     SLOT_MEMORY_MB = "128"
@@ -22,6 +23,7 @@ class TestConfig(unittest.TestCase):
             "DOCKER_NODES": "{},{}".format(self.DOCKER_NODE_1, self.DOCKER_NODE_2),
             "SLUG_RUNNER_COMMAND": self.SLUG_RUNNER_COMMAND,
             "SLUG_RUNNER_IMAGE": self.SLUG_RUNNER_IMAGE,
+            "SLUG_RUNNER_VERSION": self.SLUG_RUNNER_VERSION,
             "DOCKER_GC_GRACE_PERIOD": self.DOCKER_GC_GRACE_PERIOD,
             "SLOTS_PER_NODE": self.SLOTS_PER_NODE,
             "SLOT_MEMORY_MB": self.SLOT_MEMORY_MB,
@@ -36,6 +38,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(config.docker_nodes, [self.DOCKER_NODE_1, self.DOCKER_NODE_2])
         self.assertEqual(config.slug_runner_command, self.SLUG_RUNNER_COMMAND)
         self.assertEqual(config.slug_runner_image, self.SLUG_RUNNER_IMAGE)
+        self.assertEqual(config.slug_runner_version, self.SLUG_RUNNER_VERSION)
         self.assertEqual(config.docker_gc_grace_period, int(self.DOCKER_GC_GRACE_PERIOD))
 
         self.assertEqual(config.slots_per_node, int(self.SLOTS_PER_NODE))
@@ -47,7 +50,7 @@ class TestConfig(unittest.TestCase):
         # given
         environment = {
             "SLUG_RUNNER_COMMAND": self.SLUG_RUNNER_COMMAND,
-            "SLUG_RUNNER_IMAGE": self.SLUG_RUNNER_IMAGE
+            "SLUG_RUNNER_IMAGE": self.SLUG_RUNNER_IMAGE,
         }
         self.mock_environment(mock_getenv, environment)
 
@@ -58,6 +61,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(config.docker_nodes, ["http://localhost:5000"])
         self.assertEqual(config.slug_runner_command, self.SLUG_RUNNER_COMMAND)
         self.assertEqual(config.slug_runner_image, self.SLUG_RUNNER_IMAGE)
+        self.assertEqual(config.slug_runner_version, '0.0.0')
 
         self.assertEqual(config.slug_runner_command, self.SLUG_RUNNER_COMMAND)
         self.assertEqual(config.slug_runner_image, self.SLUG_RUNNER_IMAGE)

--- a/captain/tests/test_config.py
+++ b/captain/tests/test_config.py
@@ -63,8 +63,6 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(config.slug_runner_image, self.SLUG_RUNNER_IMAGE)
         self.assertEqual(config.slug_runner_version, '0.0.0')
 
-        self.assertEqual(config.slug_runner_command, self.SLUG_RUNNER_COMMAND)
-        self.assertEqual(config.slug_runner_image, self.SLUG_RUNNER_IMAGE)
         self.assertEqual(config.docker_gc_grace_period, 86400)
 
         self.assertEqual(config.slots_per_node, 110)


### PR DESCRIPTION
We want to launch different containers with different `slug_runner` versions; this PR will introduce an optional parameter to do just that.

See individual commits for more details